### PR TITLE
Set parent flag to make-directory

### DIFF
--- a/temporary-persistent.el
+++ b/temporary-persistent.el
@@ -85,7 +85,7 @@
                            buffer-name-template))
          (temp-file-path (progn
                            (unless (file-exists-p store-folder)
-                             (make-directory store-folder))
+                             (make-directory store-folder t))
                            (expand-file-name temp-file-name store-folder)))
          (temp-buffer-name (concat "*" temp-file-name "*")
                            buffer-name-template))


### PR DESCRIPTION
make-directory fails if parent directory of store-folder is not existed. (For example `store-folder` is `~/not_existed_directory/temp`)