### PR TITLE
Fix packaging

### DIFF
--- a/temporary-persistent.el
+++ b/temporary-persistent.el
@@ -33,6 +33,8 @@
 ;; Furtermore, you can save them manually any time via `save-buffer' function.
 ;; See README.md for more information.
 
+;;; Code:
+
 (require 's)
 (require 'dash)
 (require 'names)


### PR DESCRIPTION
`;;; Code:` can be used to mark the end the Commentary. Emacs won't be able to generate a correct commentary without it.