### PR TITLE
Fix buffer-local variable comment suffix

### DIFF
--- a/temporary-persistent.el
+++ b/temporary-persistent.el
@@ -1,4 +1,4 @@
-;;; temporary-persistent.el --- Keep temp notes buffers persistent -*- lexical-binding: t
+;;; temporary-persistent.el --- Keep temp notes buffers persistent -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2016 Kostafey <kostafey@gmail.com>
 


### PR DESCRIPTION
Hi!
I found this package at MELPA and found this package summary is "Keep temp notes buffers persistent -*- lexical-binding: t".
It seems to lack suffix specifing buffer-local variable.